### PR TITLE
Pin python-nest version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.3.1
 
 - Pinned `python-nest` to < 3.0. Newer versions require OAuth setup
+- Fixed parameter type for device/structure in config.schema - should be integer
 
 ## 0.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,17 @@
 # Change Log
 
-# 0.3.0
+## 0.3.1
+
+- Pinned `python-nest` to < 3.0. Newer versions require OAuth setup
+
+## 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
 
-# 0.2.0
+## 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.
 
-# 0.1.0
+## 0.1.0
 
 - First release 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -11,13 +11,13 @@
     required: true
   structure:
     description: "Default nest home ID to query (Default: 0)"
-    type: "string"
+    type: "integer"
     secret: false
     required: false
-    default: "0"
+    default: 0
   device:
     description: "Default nest device ID to query (Default: 0)"
-    type: "string"
+    type: integer
     secret: false
     required: false
-    default: "0"
+    default: 0

--- a/nest.yaml.example
+++ b/nest.yaml.example
@@ -1,5 +1,5 @@
 ---
 username: ""
 password: ""
-structure: "0"
-device: "0"
+structure: 0
+device: 0

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,10 @@
 ---
 ref: nest
 name: nest
-description: StackStorm integration with Nest Thermostats
-version: 0.3.0
+description: Nest Home Device Control
+keywords:
+  - nest
+  - home automation
+version: 0.3.1
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-nest
+python-nest<3.0
 pytz


### PR DESCRIPTION
Pins python-nest version to < 3.0. Newer versions require OAuth.

Fixes #2 